### PR TITLE
doc: fixed invalid link to main website in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ And run with your custom configuration:
 
 Or get the Docker image from [Dockerhub: danielszabo99/microbin](https://hub.docker.com/r/danielszabo99/microbin)
 
-On our website [microbin.eu](microbin.eu) you will find the following:
+On our website [microbin.eu](https://microbin.eu) you will find the following:
 
 - [Screenshots](https://microbin.eu/screenshots/)
 - [Quickstart Guide](https://microbin.eu/quickstart/)


### PR DESCRIPTION
Link to a resource outside the repo itself should be prepended with https.